### PR TITLE
💚 Fix: Prevent multiple progress bars when receiving Competitive Companion messages

### DIFF
--- a/src/main/kotlin/com/github/pushpavel/autocp/gather/base/ProblemGatheringBridge.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/gather/base/ProblemGatheringBridge.kt
@@ -3,11 +3,17 @@ package com.github.pushpavel.autocp.gather.base
 import com.github.pushpavel.autocp.common.helpers.ioScope
 import com.github.pushpavel.autocp.common.res.R
 import com.github.pushpavel.autocp.gather.models.ProblemJson
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
@@ -15,21 +21,41 @@ import java.net.SocketTimeoutException
 
 /**
  * Bridge between Competitive Companion extension and [BatchProcessor]
+ * Application-level service to ensure only one instance is running
  */
-class ProblemGatheringBridge : ProjectActivity, DumbAware {
+@Service(Service.Level.APP)
+class ProblemGatheringBridge : Disposable {
     private val scope = ioScope()
     private val serializer = Json { ignoreUnknownKeys = true }
+    
+    @Volatile
+    private var isRunning = false
+    
+    @Volatile
+    private var serverJob: Job? = null
 
-    fun runActivity(project: Project) {
+    companion object {
+        fun getInstance(): ProblemGatheringBridge {
+            return ApplicationManager.getApplication().getService(ProblemGatheringBridge::class.java)
+        }
+    }
+
+    fun start() {
+        if (isRunning) {
+            return
+        }
+        
+        isRunning = true
+        
         // initialize server
-        scope.launch {
+        serverJob = scope.launch {
             try {
                 val serverSocket = openServerSocketAsync(
                     R.others.competitiveCompanionPorts
                 ).await() ?: throw ProblemGatheringErr.AllPortsTakenErr(R.others.competitiveCompanionPorts)
 
                 serverSocket.use {
-                    while (true) {
+                    while (isActive) {
                         try {
                             coroutineScope {
                                 val message = listenForMessageAsync(
@@ -51,12 +77,31 @@ class ProblemGatheringBridge : ProjectActivity, DumbAware {
             } catch (e: ProblemGatheringErr) {
                 R.notify.problemGatheringErr(e)
             } catch (e: Exception) {
-                R.notify.problemGatheringUncaught(e)
+                if (e !is CancellationException) {
+                    R.notify.problemGatheringUncaught(e)
+                }
             } finally {
+                isRunning = false
                 BatchProcessor.interruptBatch()
             }
         }
     }
 
-    override suspend fun execute(project: Project) = runActivity(project)
+    fun stop() {
+        serverJob?.cancel()
+        isRunning = false
+    }
+    
+    override fun dispose() {
+        stop()
+    }
+}
+
+/**
+ * Starts the ProblemGatheringBridge service when the first project opens
+ */
+class ProblemGatheringBridgeStarter : ProjectActivity, DumbAware {
+    override suspend fun execute(project: Project) {
+        ProblemGatheringBridge.getInstance().start()
+    }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -53,7 +53,8 @@
         <project.converterProvider
                 implementation="com.github.pushpavel.autocp.common.compat.v0_5_0_eap_1.AutoCpProjectConverterProvider"
                 id="AutoCp v0.5.0-eap.1"/>
-        <postStartupActivity implementation="com.github.pushpavel.autocp.gather.base.ProblemGatheringBridge"/>
+        <applicationService serviceImplementation="com.github.pushpavel.autocp.gather.base.ProblemGatheringBridge"/>
+        <postStartupActivity implementation="com.github.pushpavel.autocp.gather.base.ProblemGatheringBridgeStarter"/>
 
         <executor implementation="com.github.pushpavel.autocp.core.runner.AutoCpExecutor"/>
         <executor implementation="com.github.pushpavel.autocp.core.runner.AutoCpStressExecutor"/>


### PR DESCRIPTION
## Problem

<img width="463" height="41" alt="image" src="https://github.com/user-attachments/assets/a78b7a45-472d-4d11-8a68-a6c0d4eefcec" />


<img width="428" height="392" alt="image" src="https://github.com/user-attachments/assets/15c60107-905f-4a6b-8649-c8cfdf4d7e20" />

When receiving problems from Competitive Companion browser extension, multiple identical "Gathering problems..." progress bars appear simultaneously (typically 5 or more), causing UI clutter and confusion (even in situation of opening one project).

## Root

I think the problem was caused by the old implementation: every time I opened the project, a new ProblemGatheringBridge instance would be created, but the old ones weren't being cleaned up. This led to multiple instances running simultaneously, each showing its own progress bar.

## What Changed

I refactored `ProblemGatheringBridge` to be an application-level service instead of a ProjectActivity. Now there's only one instance running across all projects, which means:

- Only one listener on one port
- Proper cleanup when the service stops
- Added an `isRunning` flag to prevent duplicate starts

Created a separate `ProblemGatheringBridgeStarter` class that initializes 
the service when the first project opens.

## Testing

After rebuilding and reinstalling the plugin with this fix, the issue is gone.