### PR TITLE
Reload .autocp when modified externally

### DIFF
--- a/src/main/kotlin/com/github/pushpavel/autocp/database/AutoCpDatabase.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/database/AutoCpDatabase.kt
@@ -10,13 +10,22 @@ class AutoCpDatabase(
 ) {
     val problems get() = problemsFlow.value
 
+    /**
+     * true once the in-memory state diverged from what was loaded from disk,
+     * so an intentionally emptied database is distinguishable from a never-populated one
+     */
+    @Volatile
+    var mutated = false
+
     fun updateProblem(problem: Problem) {
+        mutated = true
         val group = this.problems[problem.groupName]?.toMutableMap() ?: mutableMapOf()
         group[problem.name] = problem
         this.problemsFlow.value = problems.toMutableMap().apply { this[problem.groupName] = group }
     }
 
     fun modifySolutionFiles(action: MutableMap<String, SolutionFile>.() -> Unit) {
+        mutated = true
         solutionFilesFlow.value = solutionFilesFlow.value.toMutableMap().apply(action)
     }
 }

--- a/src/main/kotlin/com/github/pushpavel/autocp/database/AutoCpExternalReloader.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/database/AutoCpExternalReloader.kt
@@ -4,20 +4,21 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.vfs.newvfs.BulkFileListener
 import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent
 
 class AutoCpExternalReloader : BulkFileListener {
 
     override fun after(events: List<VFileEvent>) {
         val autocpEvents = events.asSequence()
-            .filterIsInstance<VFileContentChangeEvent>()
-            .filter { it.file.name == ".autocp" }
+            .filter { it is VFileContentChangeEvent || it is VFileCreateEvent }
+            .filter { it.file?.name == ".autocp" }
             .toList()
         if (autocpEvents.isEmpty()) return
 
         val openProjects = ProjectManager.getInstanceIfCreated()?.openProjects ?: return
         for (event in autocpEvents) {
-            val parentPath = event.file.parent?.path ?: continue
+            val parentPath = event.file?.parent?.path ?: continue
             for (project in openProjects) {
                 if (project.isDefault) continue
                 if (project.basePath == parentPath) {

--- a/src/main/kotlin/com/github/pushpavel/autocp/database/AutoCpExternalReloader.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/database/AutoCpExternalReloader.kt
@@ -1,0 +1,29 @@
+package com.github.pushpavel.autocp.database
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.vfs.newvfs.BulkFileListener
+import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+
+class AutoCpExternalReloader : BulkFileListener {
+
+    override fun after(events: List<VFileEvent>) {
+        val autocpEvents = events.asSequence()
+            .filterIsInstance<VFileContentChangeEvent>()
+            .filter { it.file.name == ".autocp" }
+            .toList()
+        if (autocpEvents.isEmpty()) return
+
+        val openProjects = ProjectManager.getInstanceIfCreated()?.openProjects ?: return
+        for (event in autocpEvents) {
+            val parentPath = event.file.parent?.path ?: continue
+            for (project in openProjects) {
+                if (project.isDefault) continue
+                if (project.basePath == parentPath) {
+                    project.service<AutoCpStorage>().reloadFromDisk()
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/github/pushpavel/autocp/database/AutoCpExternalReloader.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/database/AutoCpExternalReloader.kt
@@ -1,7 +1,9 @@
 package com.github.pushpavel.autocp.database
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.newvfs.BulkFileListener
 import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
 import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
@@ -11,20 +13,24 @@ class AutoCpExternalReloader : BulkFileListener {
 
     override fun after(events: List<VFileEvent>) {
         val autocpEvents = events.asSequence()
-            .filter { it is VFileContentChangeEvent || it is VFileCreateEvent }
-            .filter { it.file?.name == ".autocp" }
+            .filter { it is VFileCreateEvent || (it is VFileContentChangeEvent && !it.isFromSave) }
+            .filter { it.path.endsWith("/.autocp") }
             .toList()
         if (autocpEvents.isEmpty()) return
 
         val openProjects = ProjectManager.getInstanceIfCreated()?.openProjects ?: return
-        for (event in autocpEvents) {
-            val parentPath = event.file?.parent?.path ?: continue
-            for (project in openProjects) {
-                if (project.isDefault) continue
-                if (project.basePath == parentPath) {
-                    project.service<AutoCpStorage>().reloadFromDisk()
-                }
+        val affectedProjects = autocpEvents
+            .map { it.path.removeSuffix("/.autocp") }
+            .flatMap { parentPath ->
+                openProjects.filter { !it.isDefault && FileUtil.pathsEqual(it.basePath, parentPath) }
             }
+            .toSet()
+
+        // defer disk I/O out of the write action that delivered the VFS events
+        for (project in affectedProjects) {
+            ApplicationManager.getApplication().invokeLater({
+                project.service<AutoCpStorage>().reloadFromDisk()
+            }, project.disposed)
         }
     }
 }

--- a/src/main/kotlin/com/github/pushpavel/autocp/database/AutoCpStorage.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/database/AutoCpStorage.kt
@@ -111,6 +111,10 @@ class AutoCpStorageSaver : FileDocumentManagerListener {
                     R.notify.couldNotWriteToAutoCpFile()
                     return@runReadAction
                 }
+                if (db == DEFAULT_AUTO_CP_DB && document.text.isNotBlank()) {
+                    project.service<AutoCpStorage>().reloadFromDisk()
+                    return@runReadAction
+                }
                 val newText = Json.encodeToString(db)
                 if (document.text == newText) return@runReadAction
                 runWriteAction {

--- a/src/main/kotlin/com/github/pushpavel/autocp/database/AutoCpStorage.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/database/AutoCpStorage.kt
@@ -28,7 +28,7 @@ class AutoCpStorage(val project: Project) {
 
     val log = Logger.getInstance(AutoCpStorage::class.java)
 
-    val database by lazy {
+    private val databaseDelegate = lazy {
         if(!project.isDefault){
             val converter = AutoCpFileConversion(project)
             converter.convert()
@@ -49,6 +49,24 @@ class AutoCpStorage(val project: Project) {
         }
 
         AutoCpDatabase(MutableStateFlow(db.problems), MutableStateFlow(db.solutionFiles))
+    }
+
+    val database by databaseDelegate
+
+    fun reloadFromDisk() {
+        if (project.isDefault) return
+        if (!databaseDelegate.isInitialized()) return
+        val path = Paths.get(project.basePath!!, ".autocp")
+        if (!path.exists()) return
+        try {
+            val newDb = Migrations.migrateDB(runReadAction {
+                Json.parseToJsonElement(path.readText())
+            })
+            database.problemsFlow.value = newDb.problems
+            database.solutionFilesFlow.value = newDb.solutionFiles
+        } catch (e: Exception) {
+            log.warn("Failed to reload .autocp from disk", e)
+        }
     }
 
     val serializableDatabase
@@ -93,8 +111,10 @@ class AutoCpStorageSaver : FileDocumentManagerListener {
                     R.notify.couldNotWriteToAutoCpFile()
                     return@runReadAction
                 }
+                val newText = Json.encodeToString(db)
+                if (document.text == newText) return@runReadAction
                 runWriteAction {
-                    document.setText(Json.encodeToString(db))
+                    document.setText(newText)
                 }
             }
         }

--- a/src/main/kotlin/com/github/pushpavel/autocp/database/AutoCpStorage.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/database/AutoCpStorage.kt
@@ -64,6 +64,7 @@ class AutoCpStorage(val project: Project) {
             })
             database.problemsFlow.value = newDb.problems
             database.solutionFilesFlow.value = newDb.solutionFiles
+            database.mutated = false
         } catch (e: Exception) {
             log.warn("Failed to reload .autocp from disk", e)
         }
@@ -88,7 +89,8 @@ class AutoCpStorageSaver : FileDocumentManagerListener {
                 return
             val path = Paths.get(Path(project.basePath!!).pathString, ".autocp")
             var virtualFile = VfsUtil.findFile(path, true)
-            val db = project.service<AutoCpStorage>().serializableDatabase
+            val storage = project.service<AutoCpStorage>()
+            val db = storage.serializableDatabase
 
 
             if (virtualFile?.isValid != true && DEFAULT_AUTO_CP_DB != db) {
@@ -111,8 +113,9 @@ class AutoCpStorageSaver : FileDocumentManagerListener {
                     R.notify.couldNotWriteToAutoCpFile()
                     return@runReadAction
                 }
-                if (db == DEFAULT_AUTO_CP_DB && document.text.isNotBlank()) {
-                    project.service<AutoCpStorage>().reloadFromDisk()
+                // in-memory state was never populated, prefer the on-disk content over clobbering it
+                if (!storage.database.mutated && db == DEFAULT_AUTO_CP_DB && document.text.isNotBlank()) {
+                    storage.reloadFromDisk()
                     return@runReadAction
                 }
                 val newText = Json.encodeToString(db)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -62,6 +62,10 @@
         <programRunner implementation="com.github.pushpavel.autocp.config.AutoCpProgramRunner"/>
         <executionTargetProvider implementation="com.github.pushpavel.autocp.config.AutoCpExecutionTargetProvider"/>
     </extensions>
+    <applicationListeners>
+        <listener class="com.github.pushpavel.autocp.database.AutoCpExternalReloader"
+                  topic="com.intellij.openapi.vfs.newvfs.BulkFileListener"/>
+    </applicationListeners>
     <projectListeners>
         <listener class="com.github.pushpavel.autocp.extend.cmake.CMakeAddExecutable"
                   topic="com.github.pushpavel.autocp.gather.filegen.FileGenerationListener"/>


### PR DESCRIPTION
## Motivation

`.autocp` is loaded once via `by lazy` and only ever written to, so any external edit (a script, another editor, an AI tool) gets silently overwritten by `AutoCpStorageSaver` on the next `saveAllDocuments` using stale in-memory state.

## Change

Register a `BulkFileListener` (application level) that calls a new `AutoCpStorage.reloadFromDisk()` whenever a file named `.autocp` under any open project's `basePath` reports a content change or creation. It re-parses through the existing `Migrations` path and resets the two `MutableStateFlow`s. Events originating from the plugin's own document saves are skipped via `isFromSave`, and the reload itself is deferred with `invokeLater` so no disk I/O runs inside VFS event delivery.

The saver also short-circuits with `if (document.text == newText) return` before `setText`, which prevents a write→fire→reload loop and avoids spurious modify events.

As a safety net for a save racing ahead of the VFS create event: if the in-memory state was never mutated (tracked by an explicit `mutated` flag on `AutoCpDatabase`, set by `updateProblem`/`modifySolutionFiles` and cleared when state is replaced from disk) and the on-disk file has content, the saver reloads instead of writing — so a default-initialized state can't clobber an externally created `.autocp`. A database the user intentionally emptied has `mutated = true` and persists normally.

External deletion of `.autocp` is intentionally ignored: in-memory state survives and the next save recreates the file.

The IDE-internal warning panel in `AutoCpFileEditor` is unchanged — direct editing inside the IDE remains blocked via `HIDE_DEFAULT_EDITOR`.

## Failure mode

If the new disk content fails to parse (invalid JSON / schema mismatch), `reloadFromDisk` catches and `log.warn`s, leaving in-memory state untouched. Once the in-memory state has been mutated, the next `saveAllDocuments` overwrites the broken file with the previous valid state — equivalent to the current "external edit silently lost" behaviour. If the plugin has nothing to persist (state never populated), it leaves the unparseable file alone rather than clobbering it.
