### PR TITLE
Fix endless loading of Project settings page when no project is open

### DIFF
--- a/src/main/kotlin/com/github/pushpavel/autocp/settings/projectSettings/cmake/cmakeProjectSection.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/settings/projectSettings/cmake/cmakeProjectSection.kt
@@ -10,8 +10,9 @@ import kotlin.io.path.exists
 
 fun Panel.cmakeProjectSection(project: Project) {
     val cmakeSettings = project.cmakeSettings()
-    val cmakeFile = Paths.get(project.basePath!!, ".autocp")
-    if (ApplicationInfo.getInstance().build.productCode == "CL" || cmakeFile.exists())
+    // basePath is null for the default project (settings opened with no project open)
+    val cmakeFile = project.basePath?.let { Paths.get(it, ".autocp") }
+    if (ApplicationInfo.getInstance().build.productCode == "CL" || cmakeFile?.exists() == true)
         row {
             checkBox(R.strings.addToCMakeMsg).bindSelected(
                 { cmakeSettings.addToCMakeLists },


### PR DESCRIPTION
**With no project open** (IDE Welcome screen), opening `Settings > Tools > AutoCp > Project` never finishes loading — the page shows a perpetual spinner and the settings can't be viewed or edited:

![Project settings page stuck on Loading with no project open](https://raw.githubusercontent.com/znzryb/AutoCp/media/pr-assets/autocp-project-settings-always-loading.png)

**Steps to reproduce**

1. Close all projects so the IDE shows the Welcome screen (reproduced on RustRover, but not IDE-specific).
2. Open `Settings > Tools > AutoCp > Project`.
3. The panel stays on `Loading...` indefinitely.

**Cause**

When the settings dialog is opened without a project, the platform binds project-level configurables to the *default project* (the template behind "Project-level settings will be applied to new projects"), whose `basePath` is `null`. `cmakeProjectSection` dereferences it unconditionally:

```kotlin
val cmakeFile = Paths.get(project.basePath!!, ".autocp")
```

The NPE aborts `createPanel()`, so the dialog never receives the panel and keeps showing the loading spinner.

**Fix**

Treat a null `basePath` as "no `.autocp` file": only build the path when `basePath` is present, and fall back to the existing `productCode == "CL"` check. The CMake checkbox row still appears on CLion and in any project containing `.autocp`; the page now renders normally for the default project.
