### PR TITLE
Add a setting to stop stderr output from failing a testcase

### DIFF
--- a/src/main/kotlin/com/github/pushpavel/autocp/common/res/AutoCpStrings.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/common/res/AutoCpStrings.kt
@@ -46,6 +46,9 @@ object AutoCpStrings {
     const val onlyActiveWindowText = "Only show problem dialog in the focused window"
     const val onlyActiveWindowComment = "When parsing a problem from the browser, only the most recently focused IDE window receives it. Disable to broadcast to all open projects (legacy behavior)."
 
+    const val ignoreStderrText = "Ignore output written to stderr"
+    const val ignoreStderrComment = "Debug logs printed to stderr no longer fail a testcase with a runtime error, matching how online judges verdict a submission. The verdict then depends only on the exit code and on stdout. Stderr is still shown below the testcase output. Disable to fail any testcase that writes to stderr (legacy behavior)."
+
     fun OpenFileOnGather.presentable() = when (this) {
         OpenFileOnGather.NONE -> "None"
         OpenFileOnGather.ONLY_FIRST -> "Only first"

--- a/src/main/kotlin/com/github/pushpavel/autocp/settings/generalSettings/AutoCpGeneralSettings.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/settings/generalSettings/AutoCpGeneralSettings.kt
@@ -15,6 +15,7 @@ class AutoCpGeneralSettings : PersistentStateComponent<AutoCpGeneralSettings> {
     var openFilesOnGather = OpenFileOnGather.ONLY_FIRST
     var fileGenerationRoot = "\$groupName"
     var onlyActiveWindow = true
+    var ignoreStderr = true
 
     override fun getState() = this
 
@@ -22,6 +23,7 @@ class AutoCpGeneralSettings : PersistentStateComponent<AutoCpGeneralSettings> {
         openFilesOnGather = state.openFilesOnGather
         fileGenerationRoot = state.fileGenerationRoot
         onlyActiveWindow = state.onlyActiveWindow
+        ignoreStderr = state.ignoreStderr
     }
 
     companion object {

--- a/src/main/kotlin/com/github/pushpavel/autocp/settings/generalSettings/AutoCpGeneralSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/settings/generalSettings/AutoCpGeneralSettingsConfigurable.kt
@@ -29,5 +29,12 @@ class AutoCpGeneralSettingsConfigurable : BoundConfigurable("AutoCp") {
             }
             FileGenerationRootRow().placeUI(this)
         }
+        group("Testing") {
+            row {
+                checkBox(R.strings.ignoreStderrText)
+                    .bindSelected(generalSettings::ignoreStderr)
+                    .comment(R.strings.ignoreStderrComment)
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/github/pushpavel/autocp/tester/AutoCpTestingProcessHandler.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/tester/AutoCpTestingProcessHandler.kt
@@ -10,6 +10,7 @@ import com.github.pushpavel.autocp.config.validators.getValidSolutionFile
 import com.github.pushpavel.autocp.database.models.Program
 import com.github.pushpavel.autocp.database.models.SolutionFile
 import com.github.pushpavel.autocp.database.models.Testcase
+import com.github.pushpavel.autocp.settings.generalSettings.AutoCpGeneralSettings
 import com.github.pushpavel.autocp.tester.base.*
 import com.github.pushpavel.autocp.tester.errors.TestGenerationErr
 import com.github.pushpavel.autocp.tester.tree.TestNode
@@ -104,22 +105,23 @@ class AutoCpTestingProcessHandler(val project: Project, private val config: Auto
         processFactory: ProcessFactory,
         workingDir: File
     ): TestNode {
+        val ignoreStderr = AutoCpGeneralSettings.instance.ignoreStderr
         val judge = compileIntoProcessFactory(
             solutionFile.judgeSettings.judgeProgram, "judge", File(workingDir, "judge")
-        )?.let { Judge(ProcessRunner(it, File(workingDir, "judge")), solutionFile.judgeSettings) }
-        val participant = ProcessRunner(processFactory, workingDir)
+        )?.let { Judge(ProcessRunner(it, File(workingDir, "judge"), ignoreStderr), solutionFile.judgeSettings) }
+        val participant = ProcessRunner(processFactory, workingDir, ignoreStderr)
         val staticTestcases = solutionFile.testcases.map {
             TestNode.Leaf(it.name, Testcase(it.name, it.input, it.output))
         }.asSequence()
         val generatingTestcases = suspend {
             val generator = compileIntoProcessFactory(
                 solutionFile.generator.generatorProgram, "gen", File(workingDir, "gen")
-            )?.let { ProcessRunner(it, File(workingDir, "gen")) }
+            )?.let { ProcessRunner(it, File(workingDir, "gen"), ignoreStderr) }
             if (generator == null)
                 throw TestGenerationErr.GeneratorNotProvided()
             val correct = compileIntoProcessFactory(
                 solutionFile.generator.correctProgram, "correct", File(workingDir, "correct")
-            )?.let { ProcessRunner(it, File(workingDir, "correct")) }
+            )?.let { ProcessRunner(it, File(workingDir, "correct"), ignoreStderr) }
             sequence {
                 for (i in 1..solutionFile.generator.stressTestcaseAmount) {
                     var testInput: String

--- a/src/main/kotlin/com/github/pushpavel/autocp/tester/TestcaseTreeTestingProcess.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/tester/TestcaseTreeTestingProcess.kt
@@ -32,14 +32,17 @@ class TestcaseTreeTestingProcess(rootTestNode: TestNode, reporter: Listener, pri
                 if (performance.exitCode != 0) {
                     Verdict.RuntimeErr(
                         performance["answer"] ?: "",
-                        "Solution exited with invalid exit code ${performance.exitCode}"
+                        "Solution exited with invalid exit code ${performance.exitCode}" +
+                                performance.stderr.ifEmpty { null }?.let { "\n\n$it" }.orEmpty()
                     )
                 } else {
                     val answer = performance["answer"]?.trimByLines() ?: ""
                     if (!answer.contentEquals(expectedOutput))
-                        Verdict.WrongAnswer(node.testcase.output, answer, performance.executionTime)
+                        Verdict.WrongAnswer(
+                            node.testcase.output, answer, performance.executionTime, null, performance.stderr
+                        )
                     else
-                        Verdict.CorrectAnswer(answer, performance.executionTime)
+                        Verdict.CorrectAnswer(answer, performance.executionTime, null, performance.stderr)
                 }
             }
         } catch (e: Exception) {

--- a/src/main/kotlin/com/github/pushpavel/autocp/tester/TreeTestingProcessReporter.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/tester/TreeTestingProcessReporter.kt
@@ -29,9 +29,11 @@ class TreeTestingProcessReporter(private val processHandler: ProcessHandler) : T
     override fun leafFinish(node: ResultNode.Leaf) {
         val nodeName = node.sourceNode.name
         if (node.verdict is com.github.pushpavel.autocp.tester.errors.Verdict.CorrectAnswer) {
+            testStdOut(nodeName).addAttribute("out", node.verdict.output + '\n').apply()
+            reportStderr(nodeName, node.verdict.stderr)
             testStdOut(nodeName).addAttribute(
                 "out",
-                node.verdict.output + '\n' + R.strings.verdictOneLine(node.verdict) + '\n' +
+                R.strings.verdictOneLine(node.verdict) + '\n' +
                 (node.verdict.comment?.trim()?.let { "judge's comment: $it\n" } ?: "")
             ).apply()
 
@@ -45,6 +47,7 @@ class TreeTestingProcessReporter(private val processHandler: ProcessHandler) : T
         when (node.verdict) {
             is com.github.pushpavel.autocp.tester.errors.Verdict.WrongAnswer -> {
                 testStdOut(nodeName).addAttribute("out", node.verdict.actualOutput + '\n').apply()
+                reportStderr(nodeName, node.verdict.stderr)
 
                 testFailed(nodeName)
                     .addAttribute("message",
@@ -137,6 +140,19 @@ class TreeTestingProcessReporter(private val processHandler: ProcessHandler) : T
 
     override fun testingProcessError(message: String) {
         processHandler.notifyTextAvailable(message + "\n", ProcessOutputTypes.STDERR)
+    }
+
+    /**
+     * reports the captured error stream of a testcase through the error channel so that
+     * debug logs stay visible and keep their distinct color once they no longer decide the verdict
+     */
+    private fun reportStderr(nodeName: String, stderr: String) {
+        val trimmed = stderr.trim()
+        if (trimmed.isEmpty()) return
+        testStdErr(nodeName).addAttribute(
+            "out",
+            "${"___".repeat(5)}[ stderr ]${"___".repeat(5)}\n$trimmed\n"
+        ).apply()
     }
 
     private fun ServiceMessageBuilder.apply() {

--- a/src/main/kotlin/com/github/pushpavel/autocp/tester/base/Judge.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/tester/base/Judge.kt
@@ -26,7 +26,8 @@ class Judge(private val judge: ProcessRunner, private val settings: JudgeSetting
         if (performance.exitCode != 0)
             return Verdict.RuntimeErr(
                 performance["answer"] ?: "",
-                "Solution exited with invalid exit code ${performance.exitCode}"
+                "Solution exited with invalid exit code ${performance.exitCode}" +
+                        performance.stderr.ifEmpty { null }?.let { "\n\n$it" }.orEmpty()
             )
         val judged = judge
             .setInput(testcase.input, "input.txt")
@@ -35,8 +36,12 @@ class Judge(private val judge: ProcessRunner, private val settings: JudgeSetting
             .registerOutput("comment", "comment.txt")
             .run()
         return when (judged.exitCode) {
-            0 -> Verdict.CorrectAnswer(performance["answer"] ?: "", performance.executionTime, judged["comment"])
-            1 -> Verdict.WrongAnswer(testcase.output, performance["answer"] ?: "", performance.executionTime, judged["comment"])
+            0 -> Verdict.CorrectAnswer(
+                performance["answer"] ?: "", performance.executionTime, judged["comment"], performance.stderr
+            )
+            1 -> Verdict.WrongAnswer(
+                testcase.output, performance["answer"] ?: "", performance.executionTime, judged["comment"], performance.stderr
+            )
             else -> throw TestcaseJudgingErr.JudgeFailed(performance["answer"] ?: "", "Judge exited with invalid exit code ${judged.exitCode}", judged.exitCode)
         }
     }
@@ -57,8 +62,12 @@ class Judge(private val judge: ProcessRunner, private val settings: JudgeSetting
         participantJob.invokeOnCompletion { judge.terminateInput() }
         val (performance, judged) = awaitAll(participantJob, judgeJob)
         return@coroutineScope when (judged.exitCode) {
-            0 -> Verdict.CorrectAnswer(output.toString(), performance.executionTime, judged["comment"])
-            1 -> Verdict.WrongAnswer(testcase.output, output.toString(), performance.executionTime, judged["comment"])
+            0 -> Verdict.CorrectAnswer(
+                output.toString(), performance.executionTime, judged["comment"], performance.stderr
+            )
+            1 -> Verdict.WrongAnswer(
+                testcase.output, output.toString(), performance.executionTime, judged["comment"], performance.stderr
+            )
             else -> throw TestcaseJudgingErr.JudgeFailed(output.toString(), "Judge exited with invalid exit code ${judged.exitCode}", judged.exitCode)
         }
     }

--- a/src/main/kotlin/com/github/pushpavel/autocp/tester/base/ProcessRunner.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/tester/base/ProcessRunner.kt
@@ -14,7 +14,16 @@ import java.io.IOException
  * this enables to run a process by just calling ProcessRunner.run which returns
  * the output and errors in CapturedResults Object
  */
-class ProcessRunner(private val factory: ProcessFactory, private val workingDir: File?) {
+class ProcessRunner(
+    private val factory: ProcessFactory,
+    private val workingDir: File?,
+    /**
+     * when true, output written to the error stream is captured into
+     * [CapturedResults.stderr] instead of failing the process with
+     * [ProcessRunnerErr.RuntimeErr], letting debug logs coexist with a passing verdict
+     */
+    private val ignoreStderr: Boolean = false
+) {
 
     private val inputs: MutableMap<String?, String> = mutableMapOf()
     private val outputs: MutableMap<String, String?> = mutableMapOf()
@@ -52,7 +61,9 @@ class ProcessRunner(private val factory: ProcessFactory, private val workingDir:
                 val deferredOutput = readOutputAsync(process)
                 val executionTime = monitorProcess(process, timeLimit)
                 val exitCode = process.exitValue()
-                val stdout = deferredOutput.awaitAsResult().getOrNull()
+                val captured = deferredOutput.awaitAsResult().getOrNull()
+                val stdout = captured?.first
+                val stderr = captured?.second ?: ""
 
                 val out = mutableMapOf<String, String?>()
                 for (output in outputs) {
@@ -66,7 +77,7 @@ class ProcessRunner(private val factory: ProcessFactory, private val workingDir:
                     for (deletion in deletions)
                         File(workingDir, deletion).takeIf { it.exists() }?.delete()
 
-                CapturedResults(out, executionTime, exitCode)
+                CapturedResults(out, executionTime, exitCode, stderr)
             } finally {
                 process.destroy()
             }
@@ -145,16 +156,17 @@ class ProcessRunner(private val factory: ProcessFactory, private val workingDir:
         val error = async { process.errorStream.bufferedReader().readText() }
 
         awaitAll(output, error).let {
-            if (it[1].isNotEmpty())
+            if (!ignoreStderr && it[1].isNotEmpty())
                 throw ProcessRunnerErr.RuntimeErr(it[0], it[1])
-            it[0]
+            Pair(it[0], it[1])
         }
     }
 
     data class CapturedResults(
         val outputs: Map<String, String?>,
         val executionTime: Long,
-        val exitCode: Int
+        val exitCode: Int,
+        val stderr: String = ""
     ) {
         operator fun get(registeredOutput: String): String? {
             return outputs[registeredOutput]

--- a/src/main/kotlin/com/github/pushpavel/autocp/tester/errors/Verdict.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/tester/errors/Verdict.kt
@@ -4,8 +4,8 @@ import com.github.pushpavel.autocp.database.models.Testcase
 
 sealed interface Verdict {
 
-    class CorrectAnswer(val output: String, val executionTime: Long, val comment: String? = null) : Verdict
-    class WrongAnswer(val expectedOutput: String?, val actualOutput: String, val executionTime: Long, val comment: String? = null) : Verdict
+    class CorrectAnswer(val output: String, val executionTime: Long, val comment: String? = null, val stderr: String = "") : Verdict
+    class WrongAnswer(val expectedOutput: String?, val actualOutput: String, val executionTime: Long, val comment: String? = null, val stderr: String = "") : Verdict
     class RuntimeErr(val output: String, val errMsg: String) : Verdict
     class InternalErr(val err: Exception) : Verdict
     class TimeLimitErr(val timeLimit: Long) : Verdict


### PR DESCRIPTION
## Problem

Anything a solution writes to stderr fails the testcase with `[-] FAILURE: RUNTIME ERROR`, even when the process exits with `0` and the answer on stdout is correct. `ProcessRunner` throws `RuntimeErr` as soon as the error stream is non-empty, so a single debug print makes every testcase — normal run and stress test alike — come back red.

![stderr debug output forcing a RUNTIME ERROR verdict](https://raw.githubusercontent.com/znzryb/AutoCp/media/pr-assets/autocp-stderr-forces-runtime-error.png)

Printing intermediate state to stderr is a pretty common debugging habit while stress testing (it keeps the debug log out of the answer that gets compared), and it is exactly what online judges ignore — they verdict a submission on its exit code and stdout only. Right now that habit is unusable: the stress test stops at testcase 1 with a runtime error that says nothing about correctness.

## Change

Adds **Settings > Tools > AutoCp > Testing > "Ignore output written to stderr"**, on by default.

When it is on, the error stream is captured into the verdict instead of aborting the run, so a testcase is judged by its exit code and stdout like a judge would do. A non-zero exit code still produces a runtime error, and the captured stderr is now appended to its message, which makes crashes easier to diagnose than before. Turning the setting off restores the previous behaviour of failing any testcase that writes to stderr.

![a genuine crash still reported as RUNTIME ERROR via its exit code](https://raw.githubusercontent.com/znzryb/AutoCp/media/pr-assets/autocp-true-runtime-error-still-detected.png)

Here the solution dies on an AddressSanitizer heap-buffer-overflow with the setting on: the non-zero exit code (134) still fails the testcase as a runtime error, with the sanitizer report from stderr attached to the message.

Captured stderr is reported through `testStdErr` under the testcase output behind a `___[ stderr ]___` header, for correct and wrong answers alike. Going through the error channel keeps the debug log in its own color in the test runner, so it stays visually distinct from the answer it sits next to.

![stderr no longer deciding the verdict, kept in its own color](https://raw.githubusercontent.com/znzryb/AutoCp/media/pr-assets/autocp-stderr-ignored-and-colored.png)

The same stress test now runs to completion: the testcases whose answer matches pass with their debug log intact, and the one that is genuinely wrong is reported as a wrong answer instead of hiding behind a runtime error.

Compiling a solution is untouched: `TwoStepProcessFactory` keeps the default `ignoreStderr = false`, so a failing build still surfaces as `BuildErr` through the same path as before.

## Notes

- The setting is applied where the runners are created (`participant`, `judge`, generator and correct program), so it covers normal testing, stress testing and interactive problems.
- `ProcessRunner.CapturedResults` gained a `stderr` field with a default value, and the two verdicts gained a trailing `stderr` parameter with a default, so existing construction sites keep compiling.
