### PR TITLE
fix: catch silent compilation failures during build step

### DIFF
--- a/src/main/kotlin/com/github/pushpavel/autocp/tester/base/TwoStepProcessFactory.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/tester/base/TwoStepProcessFactory.kt
@@ -4,6 +4,7 @@ import com.github.pushpavel.autocp.build.Lang
 import com.github.pushpavel.autocp.common.helpers.pathString
 import com.github.pushpavel.autocp.database.models.Program
 import com.github.pushpavel.autocp.database.models.SolutionFile
+import com.github.pushpavel.autocp.tester.errors.ProcessRunnerErr
 import com.github.pushpavel.autocp.tester.utils.createFile
 import com.github.pushpavel.autocp.tester.utils.splitCommandString
 import com.intellij.execution.configurations.GeneralCommandLine
@@ -63,6 +64,12 @@ class TwoStepProcessFactory(private val workingDir: File, private val commandLis
                 try {
                     val factory = TwoStepProcessFactory(workingDir, buildCommandList)
                     result = ProcessRunner(factory, workingDir).run()
+                    if (result.exitCode != 0) {
+                        throw ProcessRunnerErr.RuntimeErr(
+                            result["stdout"] ?: "",
+                            "Compilation failed with exit code ${result.exitCode} but produced no error output. Check if your compiler dependencies are in your system PATH."
+                        )
+                    }
                 } catch (e: Exception) {
                     throw BuildErr(e, buildCommand)
                 }


### PR DESCRIPTION
This addresses the silent compilation failure issue discussed previously. 
