### PR TITLE
Fix: Handle non-zero exit codes and capture stdout in fromPathString

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.11.4")
     // real Socket.IO client used to verify SubmitServer speaks the cph-ng router protocol
     testImplementation("io.socket:socket.io-client:2.1.2")
-//    testImplementation("io.mockk:mockk:1.13.2")
+    testImplementation("org.mockito:mockito-core:5.11.0")
 
     // IntelliJ Platform Gradle Plugin Dependencies Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
     intellijPlatform {

--- a/src/main/kotlin/com/github/pushpavel/autocp/tester/base/TwoStepProcessFactory.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/tester/base/TwoStepProcessFactory.kt
@@ -4,6 +4,7 @@ import com.github.pushpavel.autocp.build.Lang
 import com.github.pushpavel.autocp.common.helpers.pathString
 import com.github.pushpavel.autocp.database.models.Program
 import com.github.pushpavel.autocp.database.models.SolutionFile
+import com.github.pushpavel.autocp.tester.errors.ProcessRunnerErr
 import com.github.pushpavel.autocp.tester.utils.createFile
 import com.github.pushpavel.autocp.tester.utils.splitCommandString
 import com.intellij.execution.configurations.GeneralCommandLine
@@ -63,6 +64,12 @@ class TwoStepProcessFactory(private val workingDir: File, private val commandLis
                 try {
                     val factory = TwoStepProcessFactory(workingDir, buildCommandList)
                     result = ProcessRunner(factory, workingDir).run()
+                    if (result.exitCode != 0) {
+                        throw ProcessRunnerErr.RuntimeErr(
+                            result["stdout"] ?: "",
+                            "Compilation failed with exit code ${result.exitCode} but produced no error output. Check if your compiler dependencies are in your system PATH."
+                        )
+                    }
                 } catch (e: Exception) {
                     throw BuildErr(e, buildCommand)
                 }

--- a/src/main/kotlin/com/github/pushpavel/autocp/tester/base/TwoStepProcessFactory.kt
+++ b/src/main/kotlin/com/github/pushpavel/autocp/tester/base/TwoStepProcessFactory.kt
@@ -64,10 +64,13 @@ class TwoStepProcessFactory(private val workingDir: File, private val commandLis
                 try {
                     val factory = TwoStepProcessFactory(workingDir, buildCommandList)
                     result = ProcessRunner(factory, workingDir).run()
+                    val log = result["stdout"]?.trim().orEmpty()
                     if (result.exitCode != 0) {
                         throw ProcessRunnerErr.RuntimeErr(
-                            result["stdout"] ?: "",
-                            "Compilation failed with exit code ${result.exitCode} but produced no error output. Check if your compiler dependencies are in your system PATH."
+                            log,
+                            "Compilation failed with exit code ${result.exitCode}" +
+                                if (log.isEmpty()) "\nNo output was produced by the build command."
+                                else "\n\n$log"
                         )
                     }
                 } catch (e: Exception) {

--- a/src/test/kotlin/com/github/pushpavel/autocp/tester/base/TwoStepProcessFactoryTest.kt
+++ b/src/test/kotlin/com/github/pushpavel/autocp/tester/base/TwoStepProcessFactoryTest.kt
@@ -1,0 +1,77 @@
+package com.github.pushpavel.autocp.tester.base
+
+import com.github.pushpavel.autocp.build.Lang
+import com.github.pushpavel.autocp.database.models.SolutionFile
+import com.github.pushpavel.autocp.tester.errors.ProcessRunnerErr
+import com.intellij.openapi.project.Project
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.mockito.Mockito
+import java.io.File
+import java.nio.file.Path
+
+class TwoStepProcessFactoryTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private val isWindows = System.getProperty("os.name").lowercase().contains("win")
+
+    @Test
+    fun `failed build with no output throws ProcessRunnerErr RuntimeErr with fallback message`() {
+        val project = Mockito.mock(Project::class.java)
+        val workingDir = tempDir.toFile()
+        val solutionFilePath = File(workingDir, "solution.cpp").apply { createNewFile() }.absolutePath
+        val solutionFile = SolutionFile(pathString = solutionFilePath, linkedProblemId = null, testcases = emptyList())
+
+        val buildCommand = if (isWindows) "cmd /c exit 1" else "sh -c \"exit 1\""
+        val lang = Lang("cpp", buildCommand, "echo test", true)
+
+        val buildErr = assertThrows(BuildErr::class.java) {
+            runBlocking {
+                TwoStepProcessFactory.fromSolutionFile(project, solutionFile, lang, workingDir)
+            }
+        }
+
+        val runtimeErr = assertInstanceOf(ProcessRunnerErr.RuntimeErr::class.java, buildErr.err)
+        assertEquals("", runtimeErr.output)
+        assertTrue(
+            runtimeErr.message!!.contains("\nNo output was produced by the build command."),
+            "Expected fallback message when build produces no output, but was: ${runtimeErr.message}"
+        )
+    }
+
+    @Test
+    fun `failed build with output throws ProcessRunnerErr RuntimeErr with compiler output`() {
+        val project = Mockito.mock(Project::class.java)
+        val workingDir = tempDir.toFile()
+        val solutionFilePath = File(workingDir, "solution.cpp").apply { createNewFile() }.absolutePath
+        val solutionFile = SolutionFile(pathString = solutionFilePath, linkedProblemId = null, testcases = emptyList())
+
+        val expectedOutput = "fatal error C1083: Cannot open include file"
+        val buildCommand = if (isWindows) {
+            "cmd /c \"echo $expectedOutput & exit 1\""
+        } else {
+            "sh -c \"echo '$expectedOutput' && exit 1\""
+        }
+        val lang = Lang("cpp", buildCommand, "echo test", true)
+
+        val buildErr = assertThrows(BuildErr::class.java) {
+            runBlocking {
+                TwoStepProcessFactory.fromSolutionFile(project, solutionFile, lang, workingDir)
+            }
+        }
+
+        val runtimeErr = assertInstanceOf(ProcessRunnerErr.RuntimeErr::class.java, buildErr.err)
+        assertEquals(expectedOutput, runtimeErr.output)
+        assertTrue(
+            runtimeErr.message!!.contains(expectedOutput),
+            "Expected compiler output in message, but was: ${runtimeErr.message}"
+        )
+    }
+}


### PR DESCRIPTION
Replaces PR #179.

### Description
This PR fixes a silent build failure bug where `fromPathString` was not checking the build's exit code. 

Previously, if a compiler (such as MSVC) failed but wrote its diagnostic errors to `stdout` instead of `stderr`, `ProcessRunner` would not throw an exception. The system treated the build as successful and would attempt to run a missing or stale binary. 

### Changes Made
* Added an explicit check for `result.exitCode != 0` inside `TwoStepProcessFactory.kt`.
* Captured the compiler's `stdout` output and folded it directly into the `ProcessRunnerErr.RuntimeErr` message.
* This ensures that the user is actually presented with the compiler's diagnostics rather than a generic PATH error, and it future-proofs the build step in case we later decide to ignore `stderr` warnings.